### PR TITLE
docs: Auth0リフレッシュトークン設定のドキュメント追加

### DIFF
--- a/.kiro/specs/0061-auth0-expired/prompt.md
+++ b/.kiro/specs/0061-auth0-expired/prompt.md
@@ -1,0 +1,174 @@
+/kiro:spec-requirements "https://github.com/taku-o/go-webdb-template/issues/126
+に対応するための要件を作成してください。
+GitHub CLIは入っています。
+cc-sddのfeature名は0061-auth0-expiredとしてください。"
+think.
+
+要件定義書を承認します。
+
+/kiro:spec-design 0061-auth0-expired
+
+認証エラーだけ弾きたい。403はForbiddenだから、ログアウト処理はしない。すると問題が起きる。
+> - 401または403エラーが発生した場合、ログアウト処理を実行
+
+
+セクションをどんどん追加する傾向があるみたいだが、
+既存の箇所に設定項目を増やすように記述して欲しい。
+>#### 3.3.2 追加する内容
+>
+>**追加箇所**: セクション5.2（API設定）の後に新しいセクションを追加
+
+この辺の説明とかもいらない。
+設定方法だけ書く。
+>## 5.3. リフレッシュトークンの設定
+>
+>アクセストークンの有効期限切れ時に、リフレッシュトークンを使用して自動的に新しいアクセストークンを取得できるようにするための設定です。
+> **注意**: この設定により、Auth0からリフレッシュトークンが提供されるようになります
+
+設計書を承認します。
+
+
+/kiro:spec-tasks 0061-auth0-expired
+
+タスク1.1は私がやらなければいけない作業だから、
+単独のタスク1としてください。
+タスク1.2以降はタスク2以降にタスク番号をずらす。
+> タスク 1.1: Auth0ダッシュボードの設
+
+
+今の修正でtasks.mdが壊れたみたい。
+いったん戻した方がいいかも。
+
+
+このリフレッシュトークンの取得はどうやって確認する？
+>### 実装上の注意事項
+>- **Auth0ダッシュボードの設定**: タスク 1 は手動操作が必要です。設定後、リフレッシュトークンが正しく取得できることを確認してください
+
+
+この/auth/tokenエンドポイントは、clientアプリだとログインリンクにアクセスすると発生するアクションでいい？
+>  - 確認方法:
+>    1. ログイン後、`/auth/token`エンドポイントを呼び出してアクセストークンを取得
+>    2. アクセストークンの有効期限が切れるまで待機（通常は数時間。テストの場合は、Auth0ダッシュボードでアクセストークンの有効期限を短く設定するか、手動で期限切れにする）
+>    3. 再度`/auth/token`エンドポイントを呼び出し、エラーが発生せずに新しいアクセストークンが取得できることを確認
+>    4. エラーメッセージ「The access token has expired and a refresh token was not provided. The user needs to re-authenticate.」が表示されないことを確認
+
+
+実装上の注意事項のここの部分はタスク1に移動して。
+タスク1の時に人間が見る必要がある情報だから。
+> - **Auth0ダッシュボードの設定**: タスク 1 は手動操作が必要です。設定後、リフレッシュトークンが正しく取得できることを確認してください。
+>   - 確認方法:
+>     1. ログイン後、`TodayApiButton`の「Get Today」ボタンをクリックしてアクセストークンを取得（または、ブラウザの開発者ツールで`/auth/token`エンドポイントを直接呼び出す）
+>     2. アクセストークンの有効期限が切れるまで待機（通常は数時間。テストの場合は、Auth0ダッシュボードでアクセストークンの有効期限を短く設定するか、手動で期限切れにする）
+>     3. 再度「Get Today」ボタンをクリック（または`/auth/token`エンドポイントを呼び出し）、エラーが発生せずに動作することを確認
+>     4. エラーメッセージ「The access token has expired and a refresh token was not provided. The user needs to re-authenticate.」が表示されないことを確認
+
+
+タスクリストを承認します。
+
+/sdd-fix-plan
+
+_serena_indexing
+
+/serena-initialize
+
+/kiro:spec-impl 0061-auth0-expired 1
+タスク1から取りかかるが、タスク1は私の作業です。対応する。
+
+オフラインでのアクセスを許可する
+をONにして保存した。
+
+npm run api
+npm run client
+
+手動でアクセストークンを期限切れにするにはどうすればいい？
+> 2. アクセストークンの有効期限が切れるまで待機（通常は数時間。テストの場合は、Auth0ダッシュボードでアクセストークンの有効期限を短く設定するか、手動で期限切れにする）
+
+  1. Auth0ダッシュボード > Applications > APIs > go-webdb-template API
+  2. Settings タブを開く
+  3. Token Settings セクションで Token Expiration (Seconds) を短く設定（例: 60秒）
+  4. 保存後、再ログインして新しいトークンを取得
+  5. 60秒待つとトークンが期限切れになる
+
+86400
+7200
+
+「Get Today」ボタンで次のリクエストが飛んだ。
+60秒が期限なのにトークンが切れなかった。
+ GET /auth/profile 200 in 43ms
+ GET /auth/token 200 in 457ms
+
+タスク1、確認が取れた。
+リフレッシュトークンでアクセストークンが更新されたのを確認した。
+設定はレフレッシュトークンが有効で、有効期限が長い状態にしてある。
+
+/kiro:spec-impl 0061-auth0-expired
+
+
+修正してください。
+>  テストを通過させるには:
+>  テストコードにwindow.location.hrefのモックを追加する必要があります。テストコードの修正許可をお願いします。
+
+タスク10は確認が取れている。
+
+
+リフレッシュトークンを無効にして
+アクセストークン期限切れ後にGet Todayアクセスで
+
+ GET /auth/profile 200 in 24ms
+Failed to get access token: AccessTokenError: The access token has expired and a refresh token was not provided. The user needs to re-authenticate.
+    at AuthClient.getTokenSet (webpack-internal:///(rsc)/./node_modules/@auth0/nextjs-auth0/dist/server/auth-client.js:709:17)
+    at Auth0Client.executeGetAccessToken (webpack-internal:///(rsc)/./node_modules/@auth0/nextjs-auth0/dist/server/client.js:221:68)
+
+/auth/logout にリダイレクトしたかどうかってのがわからないのと、
+クライアントの画面をリロードしても、ログイン中のままだった。
+
+
+client/src/components/TodayApiButton.tsxの作りが良くないね。
+
+ログイン中のJWTの取得ロジックは外に出して。
+全処理に、こんな処理を書くわけにはいかない。
+>      // JWTの取得
+>      let token: string
+>      if (user) {
+>        // ログイン中: Auth0 JWTを取得
+>        const response = await fetch('/auth/token')
+>        if (!response.ok) {
+>          throw new Error('Failed to get access token')
+>        }
+>        const data = await response.json()
+>        token = data.accessToken
+>      } else {
+>        // 未ログイン: Public API Keyを使用
+>        token = process.env.NEXT_PUBLIC_API_KEY!
+>      }
+
+API呼び出しも別の場所に移動。
+client/src/lib/api.ts か？
+
+まずは修正計画をたてて。
+
+
+駄目だね。想定以上にゴミのような実装だった。
+ここから直してもゴミだ。
+計画破棄。
+
+いったんgit commit。
+masterブランチからfeature/0061-auth0-expired-docを作成。
+
+次の5ファイルを
+.kiro/specs/0061-auth0-expired/prompt.md
+client/.env.development
+client/.env.production
+client/.env.staging
+docs/Partner-Idp-Auth0-Login.md
+
+feature/0061-auth0-expiredブランチからgit showで逃がす。
+
+
+逃がしたファイルをcommitして、
+https://github.com/taku-o/go-webdb-template に対して
+pull request発行。
+
+
+
+

--- a/client/.env.development
+++ b/client/.env.development
@@ -26,7 +26,10 @@ AUTH0_CLIENT_ID=YH5T1ptooPjkpaVQQCdKpNTDlK0duYT8
 AUTH0_CLIENT_SECRET=
 
 # AUTH0_AUDIENCE: Application API Idetifier
-AUTH0_AUDIENCE=https://go-webdb-template/api 
+AUTH0_AUDIENCE=https://go-webdb-template/api
+
+# AUTH0_SCOPE: 認証スコープ（offline_accessでリフレッシュトークンを取得）
+AUTH0_SCOPE='openid profile email offline_access'
 
 # E2Eテスト用のAuth0認証情報
 TEST_AUTH0_USERNAME=

--- a/client/.env.production
+++ b/client/.env.production
@@ -27,7 +27,10 @@ AUTH0_CLIENT_ID=prod-client-id
 AUTH0_CLIENT_SECRET=
 
 # AUTH0_AUDIENCE: Application API Idetifier
-AUTH0_AUDIENCE=https://go-webdb-template/api 
+AUTH0_AUDIENCE=https://go-webdb-template/api
+
+# AUTH0_SCOPE: 認証スコープ（offline_accessでリフレッシュトークンを取得）
+AUTH0_SCOPE='openid profile email offline_access'
 
 # E2Eテスト用のAuth0認証情報
 TEST_AUTH0_USERNAME=

--- a/client/.env.staging
+++ b/client/.env.staging
@@ -27,7 +27,10 @@ AUTH0_CLIENT_ID=staging-client-id
 AUTH0_CLIENT_SECRET=
 
 # AUTH0_AUDIENCE: Application API Idetifier
-AUTH0_AUDIENCE=https://go-webdb-template/api 
+AUTH0_AUDIENCE=https://go-webdb-template/api
+
+# AUTH0_SCOPE: 認証スコープ（offline_accessでリフレッシュトークンを取得）
+AUTH0_SCOPE='openid profile email offline_access'
 
 # E2Eテスト用のAuth0認証情報
 TEST_AUTH0_USERNAME=

--- a/docs/Partner-Idp-Auth0-Login.md
+++ b/docs/Partner-Idp-Auth0-Login.md
@@ -125,6 +125,9 @@ Auth0からJWT形式のアクセストークンを取得するために、APIを
    - **Identifier**: `https://go-webdb-template/api` （任意の識別子、URLである必要はないがURL形式が推奨）
    - **Signing Algorithm**: `RS256`
 5. **[Create]** をクリック
+6. `Settings` タブを開く
+7. `Allow Offline Access` を **ON** にする
+8. 画面下部の `Save Changes` をクリック
 
 ### 環境変数の設定
 
@@ -133,17 +136,20 @@ Auth0からJWT形式のアクセストークンを取得するために、APIを
 `client/.env.local` に以下を追加:
 ```
 AUTH0_AUDIENCE=https://go-webdb-template/api
+AUTH0_SCOPE='openid profile email offline_access'
 ```
 
 ### 各環境の設定例
 
-| 環境 | AUTH0_AUDIENCE |
-| --- | --- |
-| 開発環境 | `https://go-webdb-template/api` |
-| ステージング | `https://go-webdb-template/api` |
-| 本番 | `https://go-webdb-template/api` |
+| 環境 | AUTH0_AUDIENCE | AUTH0_SCOPE |
+| --- | --- | --- |
+| 開発環境 | `https://go-webdb-template/api` | `openid profile email offline_access` |
+| ステージング | `https://go-webdb-template/api` | `openid profile email offline_access` |
+| 本番 | `https://go-webdb-template/api` | `openid profile email offline_access` |
 
-**注意**: Audienceの値はAPIのIdentifierと完全に一致する必要があります。
+**注意**:
+- Audienceの値はAPIのIdentifierと完全に一致する必要があります。
+- `offline_access`スコープを含めることで、リフレッシュトークンが取得できます。
 
 ---
 


### PR DESCRIPTION
## Summary
- AUTH0_SCOPE環境変数にoffline_accessを追加（開発/本番/ステージング環境）
- Auth0ダッシュボードのAllow Offline Access設定手順をドキュメントに追加
- 0061-auth0-expired feature用のprompt.mdを追加

## Test plan
- [ ] ドキュメントの内容を確認
- [ ] 環境変数の設定値が正しいことを確認